### PR TITLE
Update snippet.filelister.php

### DIFF
--- a/core/components/filelister/elements/snippets/snippet.filelister.php
+++ b/core/components/filelister/elements/snippets/snippet.filelister.php
@@ -168,12 +168,20 @@ foreach (new DirectoryIterator($curPath) as $file) {
 
     /* if allowing for downloading, generate a link here */
     if ($file->isDir() || $canDownload) {
-        $fileArray['link'] = $fileLister->getChunk($fileLinkTpl,array(
-            'url' => $modx->makeUrl($modx->resource->get('id'),'',array(
-                $navKey => $key,
-            )),
-            'filename' => $fileArray['filename'],
-        ));
+		if($file->isDir()){
+			$url = $modx->makeUrl($modx->resource->get('id'),'',array(
+				'dp' => $filePath,
+				$navKey => $key
+			));
+		} else {
+			$url = $modx->makeUrl($modx->resource->get('id'),'',array(
+				$navKey => $key
+			));
+		}
+		$fileArray['link'] = $fileLister->getChunk($fileLinkTpl,array(
+			'url' => $url,
+			'filename' => $fileArray['filename'],
+		));
     } else {
         $fileArray['link'] = $fileArray['filename'];
     }


### PR DESCRIPTION
When listed file is a directory, add query string parameter that identifies the directory path. This makes it possible to integrate more easily with the FileUpload snippet (switching &path dynamically based on a combination of the base path [unseen by users on front end] and the supplied directory path pulled from the query string).
